### PR TITLE
SchdulerDemo, Version 1.

### DIFF
--- a/SchedulingPractice.SubWorkerRunner/Program.cs
+++ b/SchedulingPractice.SubWorkerRunner/Program.cs
@@ -50,7 +50,9 @@ namespace SchedulingPractice.SubWorkerRunner
                         });
                     }
                     else if (mode == "acetaxxxx") services.AddHostedService<HankTestTwo.HankTestProgram>();
+                    else if (mode == "jackie82422") services.AddHostedService<SubWorker.ChachaDemo.ChachaSubWorkerBackgroundService>();
                     else { throw new ArgumentOutOfRangeException($"Mode: {mode} not is not valid."); }
+                  
                 })
                 .Build();
 

--- a/SchedulingPractice.SubWorkerRunner/SchedulingPractice.SubWorkerRunner.csproj
+++ b/SchedulingPractice.SubWorkerRunner/SchedulingPractice.SubWorkerRunner.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\SubWorker.AndrewDemo\SubWorker.AndrewDemo.csproj" />
     <ProjectReference Include="..\SubWorker.AndyDemo\SubWorker.AndyDemo.csproj" />
     <ProjectReference Include="..\SubWorker.BorisDemo\SubWorker.BorisDemo.csproj" />
+    <ProjectReference Include="..\SubWorker.ChachaDemo\SubWorker.ChachaDemo.csproj" />
     <ProjectReference Include="..\SubWorker.JolinDemo\SubWorker.JolinDemo.csproj" />
     <ProjectReference Include="..\SubWorker.JulianDemo\SubWorker.JulianDemo.csproj" />
     <ProjectReference Include="..\SubWorker.JWDemo\SubWorker.JWDemo.csproj" />

--- a/SchedulingPractice.sln
+++ b/SchedulingPractice.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubWorker.AndyDemo", "SubWo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SchedulingPractice.SubWorkerRunner", "SchedulingPractice.SubWorkerRunner\SchedulingPractice.SubWorkerRunner.csproj", "{5D349423-56A0-4E03-A59F-7D1AF95B78E7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SubWorker.ChachaDemo", "SubWorker.ChachaDemo\SubWorker.ChachaDemo.csproj", "{67ECD76F-8410-436C-AF45-B783EDB7D59E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{5D349423-56A0-4E03-A59F-7D1AF95B78E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D349423-56A0-4E03-A59F-7D1AF95B78E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D349423-56A0-4E03-A59F-7D1AF95B78E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67ECD76F-8410-436C-AF45-B783EDB7D59E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67ECD76F-8410-436C-AF45-B783EDB7D59E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67ECD76F-8410-436C-AF45-B783EDB7D59E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67ECD76F-8410-436C-AF45-B783EDB7D59E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -99,6 +105,7 @@ Global
 		{7D80EF21-E6C8-46EC-8179-67D328B15335} = {5A225F28-B864-4306-B0C7-83D9CBDABF5B}
 		{32F4B1E1-4A5B-4695-9BCD-1A76F8566420} = {5A225F28-B864-4306-B0C7-83D9CBDABF5B}
 		{29711E67-24F9-4736-AAC8-BBE6831A4DEF} = {5A225F28-B864-4306-B0C7-83D9CBDABF5B}
+		{67ECD76F-8410-436C-AF45-B783EDB7D59E} = {5A225F28-B864-4306-B0C7-83D9CBDABF5B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43B102A2-F68E-4926-9EAA-6763FDDEF0B4}

--- a/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
+++ b/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
@@ -10,34 +10,33 @@ namespace SubWorker.ChachaDemo
 {
     public class ChachaSubWorkerBackgroundService : BackgroundService
     {
-        private const int ChannelCount = 5;
-        private Channel<JobInfo>[] channels;
+        private readonly int _channelCount = Environment.ProcessorCount;
+        private readonly Channel<JobInfo>[] _channels;
 
         public ChachaSubWorkerBackgroundService() {
-            channels = new Channel<JobInfo>[ChannelCount];
-            for (var i = 0; i < ChannelCount; i++) {
-                channels[i] = Channel.CreateUnbounded<JobInfo>();
+            _channels = new Channel<JobInfo>[_channelCount];
+            for (var i = 0; i < _channelCount; i++) {
+                _channels[i] = Channel.CreateUnbounded<JobInfo>();
             }
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+            await Task.Delay(1,stoppingToken);
             try {
-                var getJob = Task.Run(async () => { await GetJob(stoppingToken); }, stoppingToken);
-                Parallel.For(0, channels.Length, new ParallelOptions() {
+                Task.Run(async () => { await GetJobs(stoppingToken); }, stoppingToken);
+                Parallel.For(0, _channels.Length, new ParallelOptions() {
                     MaxDegreeOfParallelism = Environment.ProcessorCount,
                     CancellationToken = stoppingToken
                 }, async i => {
                     try {
-                        await foreach (var item in channels[i].Reader.ReadAllAsync(stoppingToken)) {
-                            await ProcessJob(item, stoppingToken);
+                        await foreach (var item in _channels[i].Reader.ReadAllAsync(stoppingToken)) {
+                            await ProcessJob(i, item, stoppingToken);
                         }
                     }
                     catch {
                         Console.WriteLine("shut down");
                     }
                 });
-
-                await Task.WhenAny(getJob);
             }
 
             catch {
@@ -45,27 +44,42 @@ namespace SubWorker.ChachaDemo
             }
         }
 
-        private async Task GetJob(CancellationToken cts) {
+        private async Task GetJobs(CancellationToken cts) {
             using var jobRepo = new JobsRepo();
             while (!cts.IsCancellationRequested) {
                 var jobs = jobRepo.GetReadyJobs(JobSettings.MinPrepareTime).ToList();
                 for (var i = 0; i < jobs.Count; i++) {
-                    var index = i % ChannelCount;
-                    await channels[index].Writer.WriteAsync(jobs[i], cts);
+                    var index = i % _channelCount;
+                    await _channels[index].Writer.WriteAsync(jobs[i], cts);
                 }
 
                 await Task.Delay(JobSettings.MinPrepareTime, cts);
             }
         }
 
-        private async Task ProcessJob(JobInfo jobInfo, CancellationToken cts) {
+        private async Task ProcessJob(int channelIndex, JobInfo jobInfo, CancellationToken cts) {
             using var jobsRepo = new JobsRepo();
-            var now = DateTime.Now;
-            if (jobInfo.RunAt > now)
-                await Task.Delay(jobInfo.RunAt.Subtract(now), cts);
             if (jobsRepo.GetJob(jobInfo.Id).State != 0) return;
-            if (jobsRepo.AcquireJobLock(jobInfo.Id))
+            if (jobsRepo.AcquireJobLock(jobInfo.Id) == false) return;
+            var now = DateTime.Now;
+            if (jobInfo.RunAt > now) {
+                try {
+                    Console.WriteLine($"Chanel index is {channelIndex}, job id is {jobInfo.Id}");
+                    await Task.Delay(jobInfo.RunAt.Subtract(now), cts);
+                }
+                catch (Exception e) {
+                    Console.WriteLine(
+                        $"Application shout down, early process job, job id is {jobInfo.Id} {e.ToString()}");
+                    jobsRepo.ProcessLockedJob(jobInfo.Id);
+                    // goto shoutDown(e);
+                }
+            }
+            else {
+                Console.WriteLine($"Delay {jobInfo.Id}");
                 jobsRepo.ProcessLockedJob(jobInfo.Id);
+            }
+
+            jobsRepo.ProcessLockedJob(jobInfo.Id);
         }
     }
 }

--- a/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
+++ b/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 
 namespace SubWorker.ChachaDemo

--- a/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
+++ b/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
@@ -33,7 +33,8 @@ namespace SubWorker.ChachaDemo
                             var item = await _channels[i].Reader.ReadAsync(stoppingToken);
                             await ProcessJob(item, stoppingToken);
                         }
-                        catch { Console.WriteLine($"channel #{i} exit.");
+                        catch {
+                            Console.WriteLine($"channel #{i} exit.");
                         }
                     }
                 });

--- a/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
+++ b/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
@@ -1,15 +1,55 @@
 using System;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using SchedulingPractice.Core;
 
 namespace SubWorker.ChachaDemo
 {
     public class ChachaSubWorkerBackgroundService : BackgroundService
     {
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            throw new NotImplementedException();
+            var channels = Channel.CreateUnbounded<JobInfo>();
+            try
+            {
+                var getJob = Task.Run(() => { GetJob(channels, stoppingToken); }, stoppingToken).ConfigureAwait(false);
+                await foreach (var item in channels.Reader.ReadAllAsync(stoppingToken))
+                {
+                   await ProcessJob(item);
+                }
+                await getJob;
+            }
+
+            catch
+            {
+                // Task.WaitAny(GetJob(channels, stoppingToken), Task.Delay(JobSettings.MinPrepareTime));
+                Console.WriteLine("Shut down...");
+            }
+        }
+
+        private void GetJob(Channel<JobInfo> channel, CancellationToken cts)
+        {
+            using var jobsRepo = new JobsRepo();
+            while (!cts.IsCancellationRequested)
+            {
+                var jobs = jobsRepo.GetReadyJobs(TimeSpan.FromSeconds(10));
+                foreach (var job in jobs)
+                {
+                    channel.Writer.TryWrite(job);
+                }
+            }
+        }
+
+        private async Task ProcessJob(JobInfo jobInfo)
+        {
+            using var jobsRepo = new JobsRepo();
+            var now = DateTime.Now;
+            if (jobInfo.RunAt > now)
+                await Task.Delay(jobInfo.RunAt.Subtract(now));
+            if (jobsRepo.AcquireJobLock(jobInfo.Id))
+                jobsRepo.ProcessLockedJob(jobInfo.Id);
         }
     }
 }

--- a/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
+++ b/SubWorker.ChachaDemo/ChachaSubWorkerBackgroundService.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Hosting;
+
+namespace SubWorker.ChachaDemo
+{
+    public class ChachaSubWorkerBackgroundService : BackgroundService
+    {
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SubWorker.ChachaDemo/Program.cs
+++ b/SubWorker.ChachaDemo/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace SubWorker.ChachaDemo
+{
+      class Program
+        {
+            static void Main(string[] args)
+            {
+                var host = new HostBuilder()
+                    .ConfigureServices((context, services) =>
+                    {
+                        //services.AddHostedService<AndrewSubWorkerBackgroundService>();
+                        services.AddHostedService<ChachaSubWorkerBackgroundService>();
+                    })
+                    .Build();
+                using (host)
+                {
+                    host.Start();
+                    host.WaitForShutdown();
+                }
+            }
+        }
+}

--- a/SubWorker.ChachaDemo/README.md
+++ b/SubWorker.ChachaDemo/README.md
@@ -1,4 +1,5 @@
 ## Version 1.0
+
 Without early lock.
 
 Environment :
@@ -6,10 +7,11 @@ Environment :
 | Item     | Configuration        |
 |----------|----------------------|
 | OS       | Windows 11 Pro       |
- | CPU      | AMD Ryzen 3700X      |
+| CPU      | AMD Ryzen 3700X      |
 | RAM      | ADATA DDR4 3200 32GB |
 | Storage  | ADATA 1TB M.2        |
 | Database | LocalDB              | 
+| Runtime  | Net 6                |
 
 ### One Instance
 
@@ -43,7 +45,9 @@ Jobs Scheduling Metrics:
 - Efficient Score:      144.22 (average + stdev)
 
 ```
+
 ### Three Instance
+
 ```Jobs Scheduling Metrics:
 
 --(action count)----------------------------------------------
@@ -73,4 +77,116 @@ Jobs Scheduling Metrics:
 - Efficient Score:      107.8 (average + stdev)
 
 Process finished with exit code 0.
+```
+Environment :
+
+| Item     | Configuration        |
+|----------|----------------------|
+| OS       | Windows 11 Pro       |
+| CPU      | AMD Ryzen 3700X      |
+| RAM      | ADATA DDR4 3200 32GB |
+| Storage  | ADATA 1TB M.2        |
+| Database | LocalDB              | 
+| Runtime  | Net Core 2.2         |
+
+### One Instance
+
+```
+Jobs Scheduling Metrics:
+
+--(action count)----------------------------------------------
+- CREATE:             1749
+- ACQUIRE_SUCCESS:    1749
+- ACQUIRE_FAILURE:    1
+- COMPLETE:           1749
+- QUERYJOB:           1754
+- QUERYLIST:          65
+
+--(state count)----------------------------------------------
+- COUNT(CREATE):      0
+- COUNT(LOCK):        0
+- COUNT(COMPLETE):    1749
+
+--(statistics)----------------------------------------------
+- DELAY(Average):     113
+- DELAY(Stdev):       30.7915205815142
+
+--(test result)----------------------------------------------
+- Complete Job:       True, 1749 / 1749
+- Delay Too Long:     0
+- Fail Job:           True, 0
+
+--(benchmark score)----------------------------------------------
+- Exec Cost Score:      8264 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
+- Efficient Score:      143.79 (average + stdev)
+
+Process finished with exit code 0.
+```
+
+### Three Instance
+
+```
+Jobs Scheduling Metrics:
+
+--(action count)----------------------------------------------
+- CREATE:             1736
+- ACQUIRE_SUCCESS:    1736
+- ACQUIRE_FAILURE:    2767
+- COMPLETE:           1736
+- QUERYJOB:           5209
+- QUERYLIST:          195
+
+--(state count)----------------------------------------------
+- COUNT(CREATE):      0
+- COUNT(LOCK):        0
+- COUNT(COMPLETE):    1736
+
+--(statistics)----------------------------------------------
+- DELAY(Average):     101
+- DELAY(Stdev):       8.04448627812101
+
+--(test result)----------------------------------------------
+- Complete Job:       True, 1736 / 1736
+- Delay Too Long:     0
+- Fail Job:           True, 0
+
+--(benchmark score)----------------------------------------------
+- Exec Cost Score:      52379 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
+- Efficient Score:      109.04 (average + stdev)
+
+Process finished with exit code 0.
+```
+
+### Five Instances
+```
+Jobs Scheduling Metrics:
+
+--(action count)----------------------------------------------
+- CREATE:             1740
+- ACQUIRE_SUCCESS:    1740
+- ACQUIRE_FAILURE:    5264
+- COMPLETE:           1740
+- QUERYJOB:           8699
+- QUERYLIST:          323
+
+--(state count)----------------------------------------------
+- COUNT(CREATE):      0
+- COUNT(LOCK):        0
+- COUNT(COMPLETE):    1740
+
+--(statistics)----------------------------------------------
+- DELAY(Average):     102
+- DELAY(Stdev):       8.63974181166169
+
+--(test result)----------------------------------------------
+- Complete Job:       True, 1740 / 1740
+- Delay Too Long:     0
+- Fail Job:           True, 0
+
+--(benchmark score)----------------------------------------------
+- Exec Cost Score:      93639 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
+- Efficient Score:      110.64 (average + stdev)
+
+Process finished with exit code 0.
+
 ```

--- a/SubWorker.ChachaDemo/README.md
+++ b/SubWorker.ChachaDemo/README.md
@@ -1,0 +1,76 @@
+## Version 1.0
+Without early lock.
+
+Environment :
+
+| Item     | Configuration        |
+|----------|----------------------|
+| OS       | Windows 11 Pro       |
+ | CPU      | AMD Ryzen 3700X      |
+| RAM      | ADATA DDR4 3200 32GB |
+| Storage  | ADATA 1TB M.2        |
+| Database | LocalDB              | 
+
+### One Instance
+
+```
+Jobs Scheduling Metrics:
+
+--(action count)----------------------------------------------
+- CREATE:             1736
+- ACQUIRE_SUCCESS:    1736
+- ACQUIRE_FAILURE:    0
+- COMPLETE:           1736
+- QUERYJOB:           1737
+- QUERYLIST:          65
+
+--(state count)----------------------------------------------
+- COUNT(CREATE):      0
+- COUNT(LOCK):        0
+- COUNT(COMPLETE):    1736
+
+--(statistics)----------------------------------------------
+- DELAY(Average):     113
+- DELAY(Stdev):       31.2237044096519
+
+--(test result)----------------------------------------------
+- Complete Job:       True, 1736 / 1736
+- Delay Too Long:     0
+- Fail Job:           True, 0
+
+--(benchmark score)----------------------------------------------
+- Exec Cost Score:      8237 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
+- Efficient Score:      144.22 (average + stdev)
+
+```
+### Three Instance
+```Jobs Scheduling Metrics:
+
+--(action count)----------------------------------------------
+- CREATE:             1758
+- ACQUIRE_SUCCESS:    1758
+- ACQUIRE_FAILURE:    2445
+- COMPLETE:           1758
+- QUERYJOB:           5275
+- QUERYLIST:          195
+
+--(state count)----------------------------------------------
+- COUNT(CREATE):      0
+- COUNT(LOCK):        0
+- COUNT(COMPLETE):    1758
+
+--(statistics)----------------------------------------------
+- DELAY(Average):     101
+- DELAY(Stdev):       6.79669291539491
+
+--(test result)----------------------------------------------
+- Complete Job:       True, 1758 / 1758
+- Delay Too Long:     0
+- Fail Job:           True, 0
+
+--(benchmark score)----------------------------------------------
+- Exec Cost Score:      49225 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
+- Efficient Score:      107.8 (average + stdev)
+
+Process finished with exit code 0.
+```

--- a/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
+++ b/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
@@ -2,12 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+      <PackageReference Include="System.Threading.Channels" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
+++ b/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
+++ b/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
@@ -3,8 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.2</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <LangVersion>7.3</LangVersion>
     </PropertyGroup>
 

--- a/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
+++ b/SubWorker.ChachaDemo/SubWorker.ChachaDemo.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>7.3</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SchedulingPractice.Core\SchedulingPractice.Core.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
測試成績同步放在專案底下的Markdown.
分別測試1,3,5個Instance的成績如下
此外因為原本使用Net 6撰寫，但看了一下SchedulingPractice.SubWorkerRunner專案需要引用
後續有改成Net Core 2.2
除了Await IAsyncIEnumerable無法使用有改成While之外，其餘內容基本是一樣的
測試結果差距也沒太多，一併附上測試結果

## Version 1.0

Without early lock.

Environment :

| Item     | Configuration        |
|----------|----------------------|
| OS       | Windows 11 Pro       |
| CPU      | AMD Ryzen 3700X      |
| RAM      | ADATA DDR4 3200 32GB |
| Storage  | ADATA 1TB M.2        |
| Database | LocalDB              | 
| Runtime  | Net 6                |

### One Instance

```
Jobs Scheduling Metrics:

--(action count)----------------------------------------------
- CREATE:             1736
- ACQUIRE_SUCCESS:    1736
- ACQUIRE_FAILURE:    0
- COMPLETE:           1736
- QUERYJOB:           1737
- QUERYLIST:          65

--(state count)----------------------------------------------
- COUNT(CREATE):      0
- COUNT(LOCK):        0
- COUNT(COMPLETE):    1736

--(statistics)----------------------------------------------
- DELAY(Average):     113
- DELAY(Stdev):       31.2237044096519

--(test result)----------------------------------------------
- Complete Job:       True, 1736 / 1736
- Delay Too Long:     0
- Fail Job:           True, 0

--(benchmark score)----------------------------------------------
- Exec Cost Score:      8237 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
- Efficient Score:      144.22 (average + stdev)

```

### Three Instance

```Jobs Scheduling Metrics:

--(action count)----------------------------------------------
- CREATE:             1758
- ACQUIRE_SUCCESS:    1758
- ACQUIRE_FAILURE:    2445
- COMPLETE:           1758
- QUERYJOB:           5275
- QUERYLIST:          195

--(state count)----------------------------------------------
- COUNT(CREATE):      0
- COUNT(LOCK):        0
- COUNT(COMPLETE):    1758

--(statistics)----------------------------------------------
- DELAY(Average):     101
- DELAY(Stdev):       6.79669291539491

--(test result)----------------------------------------------
- Complete Job:       True, 1758 / 1758
- Delay Too Long:     0
- Fail Job:           True, 0

--(benchmark score)----------------------------------------------
- Exec Cost Score:      49225 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
- Efficient Score:      107.8 (average + stdev)

Process finished with exit code 0.
```
Environment :

| Item     | Configuration        |
|----------|----------------------|
| OS       | Windows 11 Pro       |
| CPU      | AMD Ryzen 3700X      |
| RAM      | ADATA DDR4 3200 32GB |
| Storage  | ADATA 1TB M.2        |
| Database | LocalDB              | 
| Runtime  | Net Core 2.2         |

### One Instance

```
Jobs Scheduling Metrics:

--(action count)----------------------------------------------
- CREATE:             1749
- ACQUIRE_SUCCESS:    1749
- ACQUIRE_FAILURE:    1
- COMPLETE:           1749
- QUERYJOB:           1754
- QUERYLIST:          65

--(state count)----------------------------------------------
- COUNT(CREATE):      0
- COUNT(LOCK):        0
- COUNT(COMPLETE):    1749

--(statistics)----------------------------------------------
- DELAY(Average):     113
- DELAY(Stdev):       30.7915205815142

--(test result)----------------------------------------------
- Complete Job:       True, 1749 / 1749
- Delay Too Long:     0
- Fail Job:           True, 0

--(benchmark score)----------------------------------------------
- Exec Cost Score:      8264 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
- Efficient Score:      143.79 (average + stdev)

Process finished with exit code 0.
```

### Three Instance

```
Jobs Scheduling Metrics:

--(action count)----------------------------------------------
- CREATE:             1736
- ACQUIRE_SUCCESS:    1736
- ACQUIRE_FAILURE:    2767
- COMPLETE:           1736
- QUERYJOB:           5209
- QUERYLIST:          195

--(state count)----------------------------------------------
- COUNT(CREATE):      0
- COUNT(LOCK):        0
- COUNT(COMPLETE):    1736

--(statistics)----------------------------------------------
- DELAY(Average):     101
- DELAY(Stdev):       8.04448627812101

--(test result)----------------------------------------------
- Complete Job:       True, 1736 / 1736
- Delay Too Long:     0
- Fail Job:           True, 0

--(benchmark score)----------------------------------------------
- Exec Cost Score:      52379 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
- Efficient Score:      109.04 (average + stdev)

Process finished with exit code 0.
```

### Five Instances
```
Jobs Scheduling Metrics:

--(action count)----------------------------------------------
- CREATE:             1740
- ACQUIRE_SUCCESS:    1740
- ACQUIRE_FAILURE:    5264
- COMPLETE:           1740
- QUERYJOB:           8699
- QUERYLIST:          323

--(state count)----------------------------------------------
- COUNT(CREATE):      0
- COUNT(LOCK):        0
- COUNT(COMPLETE):    1740

--(statistics)----------------------------------------------
- DELAY(Average):     102
- DELAY(Stdev):       8.63974181166169

--(test result)----------------------------------------------
- Complete Job:       True, 1740 / 1740
- Delay Too Long:     0
- Fail Job:           True, 0

--(benchmark score)----------------------------------------------
- Exec Cost Score:      93639 (querylist x 100 + acquire-failure x 10 + queryjob x 1)
- Efficient Score:      110.64 (average + stdev)

Process finished with exit code 0.

```
